### PR TITLE
luarocks.bbclass: Fixup do_install to work with usrmerge feature.

### DIFF
--- a/classes/luarocks.bbclass
+++ b/classes/luarocks.bbclass
@@ -41,7 +41,8 @@ do_compile() {
 }
 
 do_install() {
-  mkdir -p "${D}${root_prefix}"
-  cp -a "${WORKDIR}/rockinst/usr" "${D}${root_prefix}"
-  chown -R root:root "${D}${root_prefix}"
+  install -d -m 0755 ${D}${libdir}
+  cp -dR ${WORKDIR}/rockinst/usr/lib/* ${D}${libdir}
+  install -d -m 0755 ${D}${datadir}
+  cp -dR ${WORKDIR}/rockinst/usr/share/* ${D}${datadir}
 }


### PR DESCRIPTION
When usrmerge is set as a distro feature, the "root_prefix" will already be "/usr" and was resulting in components being installed to "/usr/usr". Copying between the appropriate directories instead resolves this.

Additionally, this change updates the copy logic to preserve only links and not mode and permission to make the chown commands unnecessary.